### PR TITLE
Mpi develop

### DIFF
--- a/Examples/BrioWuShockTube/SingleFluidIdealSerial/Makefile
+++ b/Examples/BrioWuShockTube/SingleFluidIdealSerial/Makefile
@@ -25,7 +25,7 @@ RTFIND_INC_DIR = ./../../../Project/${PROJECT_TYPE}/CminpackLibrary/Include
 RTFIND_SRC_DIR = ./../../../Project/${PROJECT_TYPE}//CminpackLibrary/Src
 
 # C++ compiler flags
-CXXFLAGS = -Wall -std=c++11 -O0 -g
+CXXFLAGS = -Wall -std=c++11 -O3
 
 # Sources
 SRCS = simulation.cc \

--- a/Examples/KelvinHelmholtz/SingleFluidIdealRandomParallel/Makefile
+++ b/Examples/KelvinHelmholtz/SingleFluidIdealRandomParallel/Makefile
@@ -25,7 +25,7 @@ RTFIND_INC_DIR = ./../../../Project/${PROJECT_TYPE}/CminpackLibrary/Include
 RTFIND_SRC_DIR = ./../../../Project/${PROJECT_TYPE}//CminpackLibrary/Src
 
 # C++ compiler flags
-CXXFLAGS = -Wall -std=c++11 -O3 -DUSE_MPI=$(USE_MPI) -g
+CXXFLAGS = -Wall -std=c++11 -O3 -DUSE_MPI=$(USE_MPI)
 
 # Sources
 SRCS = simulation.cc \

--- a/Project/ParallelMPI/Include/simData.h
+++ b/Project/ParallelMPI/Include/simData.h
@@ -77,6 +77,8 @@ class Data
     //@}
     int
     frameSkip;             //!< Number of timesteps per file output
+    int
+    reportItersPeriod;     //!< Period with which time step data is reported to screen during program execution
     bool
     functionalSigma;       //!< Are we using a functional (vs homogeneous) conductivity?
     double
@@ -102,7 +104,6 @@ class Data
     //@}
     int
     iters,                 //!< Number of iterations that have been completed
-    reportItersPeriod,     //!< Period with which time step data is reported to screen during program execution
     //@{
     Nx, Ny, Nz;            //!< Total number of compute cells in domain in the specified direction
     //@}

--- a/Project/ParallelMPI/Include/simulation.h
+++ b/Project/ParallelMPI/Include/simulation.h
@@ -22,6 +22,9 @@
 */
 class Simulation
 {
+  public:
+
+    Data * data;                //!< Pointer to Data class containing global simulation data
 
   private:
 
@@ -40,8 +43,6 @@ class Simulation
     PlatformEnv *env;           //!< Pointer to PlatformEnv object 
 
   public:
-
-    Data * data;                //!< Pointer to Data class containing global simulation data
 
     //! Constructor
     /*!

--- a/Project/ParallelMPI/Src/platformEnv.cc
+++ b/Project/ParallelMPI/Src/platformEnv.cc
@@ -32,6 +32,11 @@ PlatformEnv::PlatformEnv(int *argcP, char **argvP[], int nxRanks, int nyRanks, i
     this->nxRanks = 1;
     this->nyRanks = 1;
     this->nzRanks = 1;
+    this->xRankId = 0;
+    this->yRankId = 0;
+    this->zRankId = 0;
+    this->rank = 0;
+    this->nProc = 1;
 #endif
 }
 

--- a/Project/ParallelMPI/Src/simulation.cc
+++ b/Project/ParallelMPI/Src/simulation.cc
@@ -110,7 +110,6 @@ void Simulation::updateTime()
   // Syntax
   Data * d(this->data);
 
-  // TODO -- pass PlatformEnv object in here and check env->rank==0
   if (env->rank == 0 && (d->iters % d->reportItersPeriod == 0 )) {
       printf("t = %f\n", d->t);
   }


### PR DESCRIPTION
Fixes a bug where PlatformEnv rank variables were not being explicitly initialized to zero for the serial (non-MPI) version. This could cause problems as these are used to initialize x, y and z arrays. It was also causing run time output to not be generated at times. 