### PR TITLE
Removed creation of old serial folders from makePaths.sh

### DIFF
--- a/makePaths.sh
+++ b/makePaths.sh
@@ -26,21 +26,6 @@ mkdir Project/CPU/Data/TimeSeries/Constants
 mkdir Project/CPU/Data/TimeSeries/Primitive
 mkdir Project/CPU/Data/TimeSeries/UserDef
 
-
-mkdir Project/Serial/Data
-mkdir Project/Serial/Data/Final
-mkdir Project/Serial/Data/Final/Auxiliary
-mkdir Project/Serial/Data/Final/Conserved
-mkdir Project/Serial/Data/Final/Primitive
-mkdir Project/Serial/Data/Final/Constants
-mkdir Project/Serial/Data/Final/Domain
-mkdir Project/Serial/Data/TimeSeries
-mkdir Project/Serial/Data/TimeSeries/Auxiliary
-mkdir Project/Serial/Data/TimeSeries/Conserved
-mkdir Project/Serial/Data/TimeSeries/Constants
-mkdir Project/Serial/Data/TimeSeries/Primitive
-mkdir Project/Serial/Data/TimeSeries/UserDef
-
 mkdir Tests/TestData
 mkdir Tests/TestData/GPU
 mkdir Tests/TestData/GPU/Auxiliary
@@ -54,12 +39,6 @@ mkdir Tests/TestData/CPU/Auxiliary
 mkdir Tests/TestData/CPU/Conserved
 mkdir Tests/TestData/CPU/Constants
 mkdir Tests/TestData/CPU/Primitive
-
-mkdir Tests/TestData/Serial
-mkdir Tests/TestData/Serial/Auxiliary
-mkdir Tests/TestData/Serial/Conserved
-mkdir Tests/TestData/Serial/Constants
-mkdir Tests/TestData/Serial/Primitive
 
 mkdir Examples/Data
 mkdir Examples/Data/Final


### PR DESCRIPTION
MakePaths.sh still contains some old serial folders. This commit solves the issue #27.